### PR TITLE
changed $TODO_SH to $TODO_FULL_SH.

### DIFF
--- a/repeat/repeat
+++ b/repeat/repeat
@@ -54,6 +54,6 @@ if [[ "$DAYS" != "" ]]; then
 fi
 
 if [[ "$LINE" != "" ]] ; then
-    $DO && "$TODO_SH" command do "$ITEM"
-    $DO && "$TODO_SH" command add "$LINE"
+    $DO && "$TODO_FULL_SH" command do "$ITEM" 
+    $DO && "$TODO_FULL_SH" command add "$LINE" 
 fi


### PR DESCRIPTION
Hi, 

I made a minor change to your script from $TODO_SH to $TODO_FULL_SH. 

The $TODO_SH was not able to find the command "do" and "add" in todo.sh. $TODO_FULL_SH was able to. This is a new variable in version 2.5.0 of todo.txt-cli.

Thank you.

Cheers,
Brian